### PR TITLE
Added RDF mime-types

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,3 +1,15 @@
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+    
+    types {
+        application/ld+json jsonld;
+        application/xml xml;
+        application/n-triples nt;
+        text/turtle ttl;
+    }
+}
+
 server {
     index index.php index.html;
     error_log  /var/log/nginx/error.log;


### PR DESCRIPTION
Otherwise the datasetregister doesn't recognize datasetdescriptions which are published under https://omeka.netwerkdigitaalerfgoed.nl/files/datacatalogs/